### PR TITLE
Remove secondary Dependencies

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,15 +10,7 @@ WriteMakefile(
 
         # Test-Modules
         Test::Class                     => 0.03,
-    
-        Attribute::Handlers		=> 0.77,	# Dependencies of Test::Class
-  	Class::ISA			=> 0.32,
-    	IO::File			=> 1.08,
-    	Storable			=> 2.04,
-    	Test::Builder			=> 0.15,
-    	Test::Builder::Tester	        => 0.09,
-    	Test::Differences		=> 0.43,
-		
+
     	Test::Exception			=> 0.10,	# minimal version depends on Test::Class
     	Test::More			=> 0.44,
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -2,23 +2,19 @@ use ExtUtils::MakeMaker;
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
 WriteMakefile(
-    'NAME'		    => 'File::Random',
-    'VERSION_FROM'	=> 'Random.pm', # finds $VERSION
-    'LICENSE'	        => 'perl',
-    'PREREQ_PM'		=> {
-        Want                            => 0,
-
+    'NAME'            => 'File::Random',
+    'VERSION_FROM'    => 'Random.pm', # finds $VERSION
+    'LICENSE'         => 'perl',
+    'PREREQ_PM'        => {
+        Want                  => 0,
         # Test-Modules
-        Test::Class                     => 0.03,
-
-    	Test::Exception			=> 0.10,	# minimal version depends on Test::Class
-    	Test::More			=> 0.44,
-
-        Test::Warn                      => 0.05,
-        Test::ManyParams                => 0,
-
-        Set::Scalar                     => 0,       # didn't know the minimal version
-        File::Temp                      => 0
+        Test::Class           => 0.03,
+        Test::Exception       => 0.10,    # minimal version depends on Test::Class
+        Test::More            => 0.44,
+        Test::Warn            => 0.05,
+        Test::ManyParams      => 0,
+        Set::Scalar           => 0,       # didn't know the minimal version
+        File::Temp            => 0
     },
     META_MERGE => {
         'meta-spec' => { version => 2 },

--- a/README
+++ b/README
@@ -76,15 +76,6 @@ DEPENDENCIES
     File::Temp
     Test::Warn
     Test::ManyParams
-  
-  Test::Class itselfs needs the following additional modules:
-    Attribute::Handlers             
-    Class::ISA                      
-    IO::File                        
-    Storable
-    Test::Builder
-    Test::Builder::Tester
-    Test::Differences    
 
   All these modules are needed only for the tests.
   You can work with the module even without them. 

--- a/Random.pm
+++ b/Random.pm
@@ -387,15 +387,7 @@ For the tests are also needed many more modules:
   File::Temp
   Test::Warn
   Test::ManyParams
-  
-Test::Class itselfs needs the following additional modules:
-  Attribute::Handlers             
-  Class::ISA                      
-  IO::File                        
-  Storable
-  Test::Builder
-  Test::Builder::Tester
-  Test::Differences    
+
 
 All these modules are needed only for the tests.
 You can work with the module even without them. 


### PR DESCRIPTION
So they won't be listed on MetaCPAN and that when the primary dependency changes they won't be out of date.