### PR TITLE
Hide the modules used from testing from CPAN

### DIFF
--- a/test/lib/ContentOfRandomFileInScalarContext.pm
+++ b/test/lib/ContentOfRandomFileInScalarContext.pm
@@ -1,4 +1,5 @@
-package ContentOfRandomFileInScalarContext;
+package
+    ContentOfRandomFileInScalarContext;
 use base qw/RandomFileMethodBase/;
 use TestConstants;
 

--- a/test/lib/ContentOfRandomFileTestOptions.pm
+++ b/test/lib/ContentOfRandomFileTestOptions.pm
@@ -1,4 +1,5 @@
-package ContentOfRandomFileTestOptions;
+package
+    ContentOfRandomFileTestOptions;
 use base qw/RandomFileMethodAllTests/;
 
 use strict;

--- a/test/lib/RandomFileCheckOption.pm
+++ b/test/lib/RandomFileCheckOption.pm
@@ -1,4 +1,5 @@
-package RandomFileCheckOption;
+package
+    RandomFileCheckOption;
 use base qw/RandomFileMethodBase/;
 use TestConstants;
 

--- a/test/lib/RandomFileMethodAllTests.pm
+++ b/test/lib/RandomFileMethodAllTests.pm
@@ -1,4 +1,5 @@
-package RandomFileMethodAllTests;
+package
+    RandomFileMethodAllTests;
 use base qw/RandomFileSimpleDirOption
             RandomFileCheckOption
 			RandomFileRecursiveOption

--- a/test/lib/RandomFileMethodBase.pm
+++ b/test/lib/RandomFileMethodBase.pm
@@ -1,4 +1,5 @@
-package RandomFileMethodBase;
+package
+    RandomFileMethodBase;
 use base qw/Test::Class/;
 use TestConstants;
 

--- a/test/lib/RandomFilePassesPathsToCheckRoutine.pm
+++ b/test/lib/RandomFilePassesPathsToCheckRoutine.pm
@@ -1,4 +1,5 @@
-package RandomFilePassesPathsToCheckRoutine;
+package
+    RandomFilePassesPathsToCheckRoutine;
 use base qw/RandomFileMethodBase/;
 use TestConstants;
 

--- a/test/lib/RandomFileRecursiveOption.pm
+++ b/test/lib/RandomFileRecursiveOption.pm
@@ -1,4 +1,5 @@
-package RandomFileRecursiveOption;
+package
+    RandomFileRecursiveOption;
 use base qw/RandomFileMethodBase/;
 use TestConstants;
 

--- a/test/lib/RandomFileSimpleDirOption.pm
+++ b/test/lib/RandomFileSimpleDirOption.pm
@@ -1,4 +1,5 @@
-package RandomFileSimpleDirOption;
+package
+    RandomFileSimpleDirOption;
 use base qw/RandomFileMethodBase/;
 use TestConstants;
 

--- a/test/lib/RandomFileWithUnknownParameters.pm
+++ b/test/lib/RandomFileWithUnknownParameters.pm
@@ -1,4 +1,5 @@
-package RandomFileWithUnknownParameters;
+package
+    RandomFileWithUnknownParameters;
 use base qw/RandomFileMethodBase/;
 use TestConstants;
 

--- a/test/lib/RandomLine.pm
+++ b/test/lib/RandomLine.pm
@@ -1,4 +1,5 @@
-package RandomLine;
+package
+    RandomLine;
 use base qw/Test::Class/;
 
 use strict;

--- a/test/lib/TestConstants.pm
+++ b/test/lib/TestConstants.pm
@@ -1,4 +1,5 @@
-package TestConstants;
+package
+    TestConstants;
 
 use strict;
 use warnings;


### PR DESCRIPTION
So they won't be indexed and won't be listed on on MetaCPAN as being
provided by this module:
https://metacpan.org/release/File-Random